### PR TITLE
Rescue Forbidden and fail with the status message

### DIFF
--- a/lib/cog_cmd/twitter/tweet.rb
+++ b/lib/cog_cmd/twitter/tweet.rb
@@ -15,6 +15,8 @@ class CogCmd::Twitter::Tweet < Cog::Command
                            "account_name" => tweet.user.screen_name}
     rescue Twitter::Error::Unauthorized
       fail("Could not authenticate; check your credentials.")
+    rescue Twitter::Error::Forbidden => ex
+      fail(ex.message)
     end
   end
 


### PR DESCRIPTION
This prevents Cog from responding with ugly stack traces like this:

```
/home/bundle/.bundle/ruby/2.2.0/gems/twitter-5.16.0/lib/twitter/rest/response/raise_error.rb:13:in `on_complete': Status is over 140 characters. (Twitter::Error::Forbidden)
    from /home/bundle/.bundle/ruby/2.2.0/gems/faraday-0.9.2/lib/faraday/response.rb:9:in`block in call'
    from /home/bundle/.bundle/ruby/2.2.0/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
    from /home/bundle/.bundle/ruby/2.2.0/gems/faraday-0.9.2/lib/faraday/response.rb:8:in`call'
    from /home/bundle/.bundle/ruby/2.2.0/gems/faraday-0.9.2/lib/faraday/request/url_encoded.rb:15:in `call'
    from /home/bundle/.bundle/ruby/2.2.0/gems/faraday-0.9.2/lib/faraday/request/multipart.rb:14:in`call'
    from /home/bundle/.bundle/ruby/2.2.0/gems/twitter-5.16.0/lib/twitter/rest/request/multipart_with_file.rb:19:in `call'
    from /home/bundle/.bundle/ruby/2.2.0/gems/faraday-0.9.2/lib/faraday/rack_builder.rb:139:in`build_response'
    from /home/bundle/.bundle/ruby/2.2.0/gems/faraday-0.9.2/lib/faraday/connection.rb:377:in `run_request'
    from /home/bundle/.bundle/ruby/2.2.0/gems/faraday-0.9.2/lib/faraday/connection.rb:177:in`post'
    from /home/bundle/.bundle/ruby/2.2.0/gems/twitter-5.16.0/lib/twitter/rest/request.rb:33:in `perform'
    from /home/bundle/.bundle/ruby/2.2.0/gems/twitter-5.16.0/lib/twitter/rest/utils.rb:50:in`perform_request'
    from /home/bundle/.bundle/ruby/2.2.0/gems/twitter-5.16.0/lib/twitter/rest/utils.rb:72:in `perform_request_with_object'
    from /home/bundle/.bundle/ruby/2.2.0/gems/twitter-5.16.0/lib/twitter/rest/utils.rb:64:in`perform_post_with_object'
    from /home/bundle/.bundle/ruby/2.2.0/gems/twitter-5.16.0/lib/twitter/rest/tweets.rb:158:in `update!'
    from /home/bundle/.bundle/ruby/2.2.0/gems/twitter-5.16.0/lib/twitter/rest/tweets.rb:128:in`update'
    from /home/bundle/lib/cog_cmd/twitter/tweet.rb:10:in `run_command'
    from /home/bundle/.bundle/ruby/2.2.0/bundler/gems/cog-rb-8213c9fe11d4/lib/cog/command.rb:39:in`execute'
    from /home/bundle/.bundle/ruby/2.2.0/bundler/gems/cog-rb-8213c9fe11d4/lib/cog/bundle.rb:37:in `run_command'
    from /home/bundle/.bundle/ruby/2.2.0/bundler/gems/cog-rb-8213c9fe11d4/lib/cog.rb:17:in`bundle'
    from /home/bundle/cog-command:10:in `<main>'
```